### PR TITLE
Reset migrations, remove useranswer-seeding

### DIFF
--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/ApplicationDbContext.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/ApplicationDbContext.cs
@@ -811,29 +811,6 @@ namespace ValhallaVaultCyberAwareness.Data
                     IsCorrect = true,
                     QuestionId = 14
                 });
-
-            builder.Entity<UserAnswers>()
-                .HasData(
-                new UserAnswers()
-                {
-                    UserId = "e547fd1c-ec07-49e1-b2ce-0d326f467c01",
-                    AnswerId = 2
-                },
-                new UserAnswers()
-                {
-                    UserId = "e547fd1c-ec07-49e1-b2ce-0d326f467c01",
-                    AnswerId = 4
-                },
-                new UserAnswers()
-                {
-                    UserId = "e547fd1c-ec07-49e1-b2ce-0d326f467c01",
-                    AnswerId = 8
-                },
-                new UserAnswers()
-                {
-                    UserId = "e547fd1c-ec07-49e1-b2ce-0d326f467c01",
-                    AnswerId = 11
-                });
         }
     }
 }

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Migrations/20240306201042_seedMoreData.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Migrations/20240306201042_seedMoreData.cs
@@ -23,17 +23,6 @@ namespace ValhallaVaultCyberAwareness.Migrations
                 });
 
             migrationBuilder.InsertData(
-                table: "UserAnswers",
-                columns: new[] { "answer_id", "user_id" },
-                values: new object[,]
-                {
-                    { 2, "e547fd1c-ec07-49e1-b2ce-0d326f467c01" },
-                    { 4, "e547fd1c-ec07-49e1-b2ce-0d326f467c01" },
-                    { 8, "e547fd1c-ec07-49e1-b2ce-0d326f467c01" },
-                    { 11, "e547fd1c-ec07-49e1-b2ce-0d326f467c01" }
-                });
-
-            migrationBuilder.InsertData(
                 table: "SubCategories",
                 columns: new[] { "id", "description", "name", "segment_id" },
                 values: new object[,]
@@ -173,26 +162,6 @@ namespace ValhallaVaultCyberAwareness.Migrations
                 table: "SubCategories",
                 keyColumn: "id",
                 keyValue: 45);
-
-            migrationBuilder.DeleteData(
-                table: "UserAnswers",
-                keyColumns: new[] { "answer_id", "user_id" },
-                keyValues: new object[] { 2, "e547fd1c-ec07-49e1-b2ce-0d326f467c01" });
-
-            migrationBuilder.DeleteData(
-                table: "UserAnswers",
-                keyColumns: new[] { "answer_id", "user_id" },
-                keyValues: new object[] { 4, "e547fd1c-ec07-49e1-b2ce-0d326f467c01" });
-
-            migrationBuilder.DeleteData(
-                table: "UserAnswers",
-                keyColumns: new[] { "answer_id", "user_id" },
-                keyValues: new object[] { 8, "e547fd1c-ec07-49e1-b2ce-0d326f467c01" });
-
-            migrationBuilder.DeleteData(
-                table: "UserAnswers",
-                keyColumns: new[] { "answer_id", "user_id" },
-                keyValues: new object[] { 11, "e547fd1c-ec07-49e1-b2ce-0d326f467c01" });
 
             migrationBuilder.DeleteData(
                 table: "Questions",

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Migrations/20240307120740_ResetDb.Designer.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Migrations/20240307120740_ResetDb.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ValhallaVaultCyberAwareness.Data;
 
@@ -11,9 +12,11 @@ using ValhallaVaultCyberAwareness.Data;
 namespace ValhallaVaultCyberAwareness.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240307120740_ResetDb")]
+    partial class ResetDb
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Migrations/20240307120740_ResetDb.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Migrations/20240307120740_ResetDb.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ValhallaVaultCyberAwareness.Migrations
+{
+    /// <inheritdoc />
+    public partial class ResetDb : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
Revert seeding of data to table "UserAnswers" as every user has a different ID in each localdb and it won't work.
Every developer will need to manually add it's own data to this table if it needs to be tested.