### PR TITLE
Add prop explanation to questionmodel, seed more data

### DIFF
--- a/ValhallaVaultCyberAwareness.Domain/Models/QuestionModel.cs
+++ b/ValhallaVaultCyberAwareness.Domain/Models/QuestionModel.cs
@@ -15,6 +15,9 @@ namespace ValhallaVaultCyberAwareness.Domain.Models
         [Column("subcategory_id")]
         public int SubCategoryId { get; set; }
 
+        [Column("explanation")]
+        public string Explanation { get; set; } = null!;
+
         //Navigation properties
 
         public SubCategoryModel? SubCategory { get; set; }

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness.Client/Services/QuestionService.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness.Client/Services/QuestionService.cs
@@ -18,7 +18,7 @@ namespace ValhallaVaultCyberAwareness.Client.Services
             if (apiResponse.IsSuccessStatusCode)
             {
                 string jsonQuestions = await apiResponse.Content.ReadAsStringAsync();
-                List<QuestionModel> allQuestions = JsonConvert.DeserializeObject<List<QuestionModel>>(jsonQuestions);
+                List<QuestionModel>? allQuestions = JsonConvert.DeserializeObject<List<QuestionModel>>(jsonQuestions);
                 if (allQuestions == null)
                 {
                     throw new JsonException();
@@ -36,7 +36,7 @@ namespace ValhallaVaultCyberAwareness.Client.Services
             if (apiResponse.IsSuccessStatusCode)
             {
                 string jsonQuestion = await apiResponse.Content.ReadAsStringAsync();
-                QuestionModel question = JsonConvert.DeserializeObject<QuestionModel>(jsonQuestion);
+                QuestionModel? question = JsonConvert.DeserializeObject<QuestionModel>(jsonQuestion);
                 if (question == null)
                 {
                     throw new JsonException();
@@ -53,9 +53,9 @@ namespace ValhallaVaultCyberAwareness.Client.Services
         {
             var apiResponse = await Client.PostAsJsonAsync("/api/question/", newQuestion);
             if (apiResponse.IsSuccessStatusCode)
-             {
+            {
                 string jsonQuestion = await apiResponse.Content.ReadAsStringAsync();
-                QuestionModel question = JsonConvert.DeserializeObject<QuestionModel>(jsonQuestion);
+                QuestionModel? question = JsonConvert.DeserializeObject<QuestionModel>(jsonQuestion);
                 return question;
             }
             throw new HttpRequestException();

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/ApplicationDbContext.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/ApplicationDbContext.cs
@@ -52,468 +52,606 @@ namespace ValhallaVaultCyberAwareness.Data
             //.HasForeignKey(u => u.UserId);
 
             //Seed data
+            SeedCategoryData(builder);
+            SeedSegmentData(builder);
+            SeedSubCategoryData(builder);
+            SeedQuestionData(builder);
+            SeedAnswerData(builder);
+        }
+
+        private void SeedCategoryData(ModelBuilder builder)
+        {
             builder.Entity<CategoryModel>()
-                .HasData(
-                new CategoryModel()
-                {
-                    Id = 1,
-                    Name = "Att skydda sig mot bedrägerier",
-                },
-                new CategoryModel()
-                {
-                    Id = 2,
-                    Name = "Cybersäkerhet för företag"
-                },
-                new CategoryModel()
-                {
-                    Id = 3,
-                    Name = "Cyberspionage"
-                });
+            .HasData(
+            new CategoryModel()
+            {
+                Id = 1,
+                Name = "Att skydda sig mot bedrägerier",
+            },
+            new CategoryModel()
+            {
+                Id = 2,
+                Name = "Cybersäkerhet för företag"
+            },
+            new CategoryModel()
+            {
+                Id = 3,
+                Name = "Cyberspionage"
+            });
+        }
+
+        private void SeedSegmentData(ModelBuilder builder)
+        {
             builder.Entity<SegmentModel>()
-                .HasData(
-                new SegmentModel()
-                {
-                    Id = 1,
-                    Name = "Del 1 - Att skydda sig mot bedrägerier",
-                    CategoryId = 1,
-                },
-                new SegmentModel()
-                {
-                    Id = 2,
-                    Name = "Del 2 - Att skydda sig mot bedrägerier",
-                    CategoryId = 1,
-                },
-                new SegmentModel()
-                {
-                    Id = 3,
-                    Name = "Del 3 - Att skydda sig mot bedrägerier",
-                    CategoryId = 1,
-                },
+            .HasData(
+            new SegmentModel()
+            {
+                Id = 1,
+                Name = "Del 1 - Att skydda sig mot bedrägerier",
+                CategoryId = 1,
+            },
+            new SegmentModel()
+            {
+                Id = 2,
+                Name = "Del 2 - Att skydda sig mot bedrägerier",
+                CategoryId = 1,
+            },
+            new SegmentModel()
+            {
+                Id = 3,
+                Name = "Del 3 - Att skydda sig mot bedrägerier",
+                CategoryId = 1,
+            },
 
-                new SegmentModel()
-                {
-                    Id = 4,
-                    Name = "Del 1 - Cybersäkerhet för företag",
-                    CategoryId = 2,
-                },
-                new SegmentModel()
-                {
-                    Id = 5,
-                    Name = "Del 2 - Cybersäkerhet för företag",
-                    CategoryId = 2,
-                },
-                new SegmentModel()
-                {
-                    Id = 6,
-                    Name = "Del 3 - Cybersäkerhet för företag",
-                    CategoryId = 2,
-                },
-                new SegmentModel()
-                {
-                    Id = 7,
-                    Name = "Del 4 - Cybersäkerhet för företag",
-                    CategoryId = 2,
-                },
-                new SegmentModel()
-                {
-                    Id = 8,
-                    Name = "Del 1 - Cyberspionage",
-                    CategoryId = 3,
-                },
-                new SegmentModel()
-                {
-                    Id = 9,
-                    Name = "Del 2 - Cyberspionage",
-                    CategoryId = 3
-                },
-                new SegmentModel()
-                {
-                    Id = 10,
-                    Name = "Del 3 - Cyberspionage",
-                    CategoryId = 3
-                });
+            new SegmentModel()
+            {
+                Id = 4,
+                Name = "Del 1 - Cybersäkerhet för företag",
+                CategoryId = 2,
+            },
+            new SegmentModel()
+            {
+                Id = 5,
+                Name = "Del 2 - Cybersäkerhet för företag",
+                CategoryId = 2,
+            },
+            new SegmentModel()
+            {
+                Id = 6,
+                Name = "Del 3 - Cybersäkerhet för företag",
+                CategoryId = 2,
+            },
+            new SegmentModel()
+            {
+                Id = 7,
+                Name = "Del 4 - Cybersäkerhet för företag",
+                CategoryId = 2,
+            },
+            new SegmentModel()
+            {
+                Id = 8,
+                Name = "Del 1 - Cyberspionage",
+                CategoryId = 3,
+            },
+            new SegmentModel()
+            {
+                Id = 9,
+                Name = "Del 2 - Cyberspionage",
+                CategoryId = 3
+            },
+            new SegmentModel()
+            {
+                Id = 10,
+                Name = "Del 3 - Cyberspionage",
+                CategoryId = 3
+            });
+        }
 
-
+        private void SeedSubCategoryData(ModelBuilder builder)
+        {
             builder.Entity<SubCategoryModel>()
-                .HasData(
+            .HasData(
 
-                new SubCategoryModel()
-                {
-                    Id = 1,
-                    Name = "Kreditkortsbedrägeri",
-                    SegmentId = 1
-                },
-                new SubCategoryModel()
-                {
-                    Id = 2,
-                    Name = "Romansbedrägeri",
-                    SegmentId = 1
-                },
-                new SubCategoryModel()
-                {
-                    Id = 3,
-                    Name = "Investeringsbedrägeri",
-                    SegmentId = 1
-                },
-                new SubCategoryModel()
-                {
-                    Id = 4,
-                    Name = "Telefonbedrägeri",
-                    SegmentId = 1
-                },
-
-
-                new SubCategoryModel()
-                {
-                    Id = 5,
-                    Name = "Bedrägerier i hemmet",
-                    SegmentId = 2
-                },
-                new SubCategoryModel()
-                {
-                    Id = 6,
-                    Name = "Identitetsstöld",
-                    SegmentId = 2
-                },
-                new SubCategoryModel()
-                {
-                    Id = 7,
-                    Name = "Nätfiske och bluffmejl",
-                    SegmentId = 2
-                },
-                new SubCategoryModel()
-                {
-                    Id = 8,
-                    Name = "Investeringsbedrägeri på nätet",
-                    SegmentId = 2
-                },
+            new SubCategoryModel()
+            {
+                Id = 1,
+                Name = "Kreditkortsbedrägeri",
+                SegmentId = 1
+            },
+            new SubCategoryModel()
+            {
+                Id = 2,
+                Name = "Romansbedrägeri",
+                SegmentId = 1
+            },
+            new SubCategoryModel()
+            {
+                Id = 3,
+                Name = "Investeringsbedrägeri",
+                SegmentId = 1
+            },
+            new SubCategoryModel()
+            {
+                Id = 4,
+                Name = "Telefonbedrägeri",
+                SegmentId = 1
+            },
 
 
-                new SubCategoryModel()
-                {
-                    Id = 9,
-                    Name = "Abonnemangsfällor och falska fakturor",
-                    SegmentId = 3
-                },
-                new SubCategoryModel()
-                {
-                    Id = 10,
-                    Name = "Ransomware",
-                    SegmentId = 3
-                },
-                new SubCategoryModel()
-                {
-                    Id = 11,
-                    Name = "Statistik och förhållningssätt",
-                    SegmentId = 3
-                },
+            new SubCategoryModel()
+            {
+                Id = 5,
+                Name = "Bedrägerier i hemmet",
+                SegmentId = 2
+            },
+            new SubCategoryModel()
+            {
+                Id = 6,
+                Name = "Identitetsstöld",
+                SegmentId = 2
+            },
+            new SubCategoryModel()
+            {
+                Id = 7,
+                Name = "Nätfiske och bluffmejl",
+                SegmentId = 2
+            },
+            new SubCategoryModel()
+            {
+                Id = 8,
+                Name = "Investeringsbedrägeri på nätet",
+                SegmentId = 2
+            },
 
 
-                new SubCategoryModel()
-                {
-                    Id = 12,
-                    Name = "Digital säkerhet på företag",
-                    SegmentId = 4
-                },
-                new SubCategoryModel()
-                {
-                    Id = 13,
-                    Name = "Risker och beredskap",
-                    SegmentId = 4
-                },
-                new SubCategoryModel()
-                {
-                    Id = 14,
-                    Name = "Aktörer inom cyberbrott",
-                    SegmentId = 4
-                },
-                new SubCategoryModel()
-                {
-                    Id = 15,
-                    Name = "Ökad digital närvaro och distansarbete",
-                    SegmentId = 4
-                },
-                new SubCategoryModel()
-                {
-                    Id = 16,
-                    Name = "Cyberangrepp mot känsliga sektorer",
-                    SegmentId = 4
-                },
-                new SubCategoryModel()
-                {
-                    Id = 17,
-                    Name = "Cyberrånet mot Mersk",
-                    SegmentId = 4
-                },
+            new SubCategoryModel()
+            {
+                Id = 9,
+                Name = "Abonnemangsfällor och falska fakturor",
+                SegmentId = 3
+            },
+            new SubCategoryModel()
+            {
+                Id = 10,
+                Name = "Ransomware",
+                SegmentId = 3
+            },
+            new SubCategoryModel()
+            {
+                Id = 11,
+                Name = "Statistik och förhållningssätt",
+                SegmentId = 3
+            },
 
 
-                new SubCategoryModel()
-                {
-                    Id = 18,
-                    Name = "Social engineering",
-                    SegmentId = 5,
-
-                },
-                new SubCategoryModel()
-                {
-                    Id = 19,
-                    Name = "Nätfiske och skräppost",
-                    SegmentId = 5,
-                },
-                new SubCategoryModel()
-                {
-                    Id = 20,
-                    Name = "Vishing",
-                    SegmentId = 5
-                },
-                new SubCategoryModel()
-                {
-                    Id = 21,
-                    Name = "Varning för vishing",
-                    SegmentId = 5
-                },
-                new SubCategoryModel()
-                {
-                    Id = 22,
-                    Name = "Identifiera VD-mejl",
-                    SegmentId = 5
-                },
-                new SubCategoryModel()
-                {
-                    Id = 23,
-                    Name = "Öneangrepp och presentkortsbluffar",
-                    SegmentId = 5
-                },
-
-
-                new SubCategoryModel()
-                {
-                    Id = 24,
-                    Name = "Virus, maskar och trojaner",
-                    SegmentId = 6
-                },
-                new SubCategoryModel()
-                {
-                    Id = 25,
-                    Name = "Så kan det gå till",
-                    SegmentId = 6
-                },
-                new SubCategoryModel()
-                {
-                    Id = 26,
-                    Name = "Nätverksintrång",
-                    SegmentId = 6
-                },
-                new SubCategoryModel()
-                {
-                    Id = 27,
-                    Name = "Dataintrång",
-                    SegmentId = 6
-                },
-                new SubCategoryModel()
-                {
-                    Id = 28,
-                    Name = "Hackad!",
-                    SegmentId = 6
-                },
-                new SubCategoryModel()
-                {
-                    Id = 29,
-                    Name = "Vägarna in",
-                    SegmentId = 6
-                },
+            new SubCategoryModel()
+            {
+                Id = 12,
+                Name = "Digital säkerhet på företag",
+                SegmentId = 4
+            },
+            new SubCategoryModel()
+            {
+                Id = 13,
+                Name = "Risker och beredskap",
+                SegmentId = 4
+            },
+            new SubCategoryModel()
+            {
+                Id = 14,
+                Name = "Aktörer inom cyberbrott",
+                SegmentId = 4
+            },
+            new SubCategoryModel()
+            {
+                Id = 15,
+                Name = "Ökad digital närvaro och distansarbete",
+                SegmentId = 4
+            },
+            new SubCategoryModel()
+            {
+                Id = 16,
+                Name = "Cyberangrepp mot känsliga sektorer",
+                SegmentId = 4
+            },
+            new SubCategoryModel()
+            {
+                Id = 17,
+                Name = "Cyberrånet mot Mersk",
+                SegmentId = 4
+            },
 
 
-                new SubCategoryModel()
-                {
-                    Id = 30,
-                    Name = "Utpressningsvirus",
-                    SegmentId = 7
-                },
-                new SubCategoryModel()
-                {
-                    Id = 31,
-                    Name = "Attacker mot servrar",
-                    SegmentId = 7
-                },
-                new SubCategoryModel()
-                {
-                    Id = 32,
-                    Name = "Cyberangrepp i Norden",
-                    SegmentId = 7
-                },
-                new SubCategoryModel()
-                {
-                    Id = 33,
-                    Name = "It-brottslingarnas verktyg",
-                    SegmentId = 7
-                },
-                new SubCategoryModel()
-                {
-                    Id = 34,
-                    Name = "Mirai, Wannacry och fallet Düsseldorf",
-                    SegmentId = 7
-                },
-                new SubCategoryModel()
-                {
-                    Id = 35,
-                    Name = "De sårbara molnen",
-                    SegmentId = 7
-                },
+            new SubCategoryModel()
+            {
+                Id = 18,
+                Name = "Social engineering",
+                SegmentId = 5,
+
+            },
+            new SubCategoryModel()
+            {
+                Id = 19,
+                Name = "Nätfiske och skräppost",
+                SegmentId = 5,
+            },
+            new SubCategoryModel()
+            {
+                Id = 20,
+                Name = "Vishing",
+                SegmentId = 5
+            },
+            new SubCategoryModel()
+            {
+                Id = 21,
+                Name = "Varning för vishing",
+                SegmentId = 5
+            },
+            new SubCategoryModel()
+            {
+                Id = 22,
+                Name = "Identifiera VD-mejl",
+                SegmentId = 5
+            },
+            new SubCategoryModel()
+            {
+                Id = 23,
+                Name = "Öneangrepp och presentkortsbluffar",
+                SegmentId = 5
+            },
 
 
-                new SubCategoryModel
-                {
-                    Id = 36,
-                    Name = "Allmänt om cyberspionage",
-                    SegmentId = 8
-                },
-                new SubCategoryModel
-                {
-                    Id = 37,
-                    Name = "Metoder för cyberspionage",
-                    SegmentId = 8
-                },
-                new SubCategoryModel
-                {
-                    Id = 38,
-                    Name = "Säkerhetsskyddslagen",
-                    SegmentId = 8
-                },
-                new SubCategoryModel
-                {
-                    Id = 39,
-                    Name = "Cyberspionagets aktörer",
-                    SegmentId = 8
-                },
+            new SubCategoryModel()
+            {
+                Id = 24,
+                Name = "Virus, maskar och trojaner",
+                SegmentId = 6
+            },
+            new SubCategoryModel()
+            {
+                Id = 25,
+                Name = "Så kan det gå till",
+                SegmentId = 6
+            },
+            new SubCategoryModel()
+            {
+                Id = 26,
+                Name = "Nätverksintrång",
+                SegmentId = 6
+            },
+            new SubCategoryModel()
+            {
+                Id = 27,
+                Name = "Dataintrång",
+                SegmentId = 6
+            },
+            new SubCategoryModel()
+            {
+                Id = 28,
+                Name = "Hackad!",
+                SegmentId = 6
+            },
+            new SubCategoryModel()
+            {
+                Id = 29,
+                Name = "Vägarna in",
+                SegmentId = 6
+            },
 
 
-                new SubCategoryModel
-                {
-                    Id = 40,
-                    Name = "Värvningsförsök",
-                    SegmentId = 9
-                },
-                new SubCategoryModel
-                {
-                    Id = 41,
-                    Name = "Affärsspionage",
-                    SegmentId = 9
-                },
-                new SubCategoryModel
-                {
-                    Id = 42,
-                    Name = "Påverkanskampanjer",
-                    SegmentId = 9
-                },
+            new SubCategoryModel()
+            {
+                Id = 30,
+                Name = "Utpressningsvirus",
+                SegmentId = 7
+            },
+            new SubCategoryModel()
+            {
+                Id = 31,
+                Name = "Attacker mot servrar",
+                SegmentId = 7
+            },
+            new SubCategoryModel()
+            {
+                Id = 32,
+                Name = "Cyberangrepp i Norden",
+                SegmentId = 7
+            },
+            new SubCategoryModel()
+            {
+                Id = 33,
+                Name = "It-brottslingarnas verktyg",
+                SegmentId = 7
+            },
+            new SubCategoryModel()
+            {
+                Id = 34,
+                Name = "Mirai, Wannacry och fallet Düsseldorf",
+                SegmentId = 7
+            },
+            new SubCategoryModel()
+            {
+                Id = 35,
+                Name = "De sårbara molnen",
+                SegmentId = 7
+            },
 
 
-                new SubCategoryModel
-                {
-                    Id = 43,
-                    Name = "Svensk underrättelsetjänst och cyberförsvar",
-                    SegmentId = 10
-                },
-                new SubCategoryModel
-                {
-                    Id = 44,
-                    Name = "Signalspaning, informationssäkerhet och 5G",
-                    SegmentId = 10
-                },
-                new SubCategoryModel
-                {
-                    Id = 45,
-                    Name = "Samverkan mot cyberspionage",
-                    SegmentId = 10
-                });
+            new SubCategoryModel
+            {
+                Id = 36,
+                Name = "Allmänt om cyberspionage",
+                SegmentId = 8
+            },
+            new SubCategoryModel
+            {
+                Id = 37,
+                Name = "Metoder för cyberspionage",
+                SegmentId = 8
+            },
+            new SubCategoryModel
+            {
+                Id = 38,
+                Name = "Säkerhetsskyddslagen",
+                SegmentId = 8
+            },
+            new SubCategoryModel
+            {
+                Id = 39,
+                Name = "Cyberspionagets aktörer",
+                SegmentId = 8
+            },
 
+
+            new SubCategoryModel
+            {
+                Id = 40,
+                Name = "Värvningsförsök",
+                SegmentId = 9
+            },
+            new SubCategoryModel
+            {
+                Id = 41,
+                Name = "Affärsspionage",
+                SegmentId = 9
+            },
+            new SubCategoryModel
+            {
+                Id = 42,
+                Name = "Påverkanskampanjer",
+                SegmentId = 9
+            },
+
+
+            new SubCategoryModel
+            {
+                Id = 43,
+                Name = "Svensk underrättelsetjänst och cyberförsvar",
+                SegmentId = 10
+            },
+            new SubCategoryModel
+            {
+                Id = 44,
+                Name = "Signalspaning, informationssäkerhet och 5G",
+                SegmentId = 10
+            },
+            new SubCategoryModel
+            {
+                Id = 45,
+                Name = "Samverkan mot cyberspionage",
+                SegmentId = 10
+            });
+        }
+        private void SeedQuestionData(ModelBuilder builder)
+        {
             builder.Entity<QuestionModel>()
-                .HasData(
-                new QuestionModel()
-                {
-                    Id = 1,
-                    Question = "Du får ett oväntat telefonsamtal från någon som påstår sig vara från din bank. Personen ber dig bekräfta ditt kontonummer och lösenord för att \"säkerställa din kontos säkerhet\" efter en påstådd säkerhetsincident. Hur bör du tolka denna situation?",
-                    SubCategoryId = 1,
-                },
-                new QuestionModel()
-                {
-                    Id = 2,
-                    Question = "Efter flera månader av daglig kommunikation med någon du träffade på en datingsida, börjar personen berätta om en plötslig finansiell kris och ber om din hjälp genom att överföra pengar. Vad indikerar detta mest sannolikt?",
-                    SubCategoryId = 2,
-                },
-                new QuestionModel()
-                {
-                    Id = 3,
-                    Question = "Du får ett e-postmeddelande/samtal om ett exklusivt erbjudande att investera i ett startup-företag som påstås ha en revolutionerande ny teknologi, med garantier om exceptionellt hög avkastning på mycket kort tid. Hur bör du förhålla dig till erbjudandet?",
-                    SubCategoryId = 3,
-                },
-                new QuestionModel()
-                {
-                    Id = 4,
-                    Question = "Efter en online-shoppingrunda märker du oidentifierade transaktioner på ditt kreditkortsutdrag från företag du aldrig handlat från. Vad indikerar detta mest sannolikt?",
-                    SubCategoryId = 4,
-                },
-                new QuestionModel()
-                {
-                    Id = 5,
-                    Question = "Inom företaget märker man att konfidentiella dokument regelbundet läcker ut till konkurrenter. Efter en intern granskning upptäcks det att en anställd omedvetet har installerat skadlig programvara genom att klicka på en länk i ett phishing-e-postmeddelande. Vilken åtgärd bör prioriteras för att förhindra framtida incidenter?",
-                    SubCategoryId = 5
-                },
-                new QuestionModel()
-                {
-                    Id = 6,
-                    Question = "Inom företaget upptäckts det en sårbarhet i vår programvara som kunde möjliggöra obehörig åtkomst till användardata. Företaget har inte omedelbart en lösning. Vilken är den mest lämpliga första åtgärden?",
-                    SubCategoryId = 6
-                },
-                new QuestionModel()
-                {
-                    Id = 7,
-                    Question = "Vårt företag blir måltavla för en DDoS-attack som överväldigar våra servrar och gör våra tjänster otillgängliga för kunder. Vilken typ av aktör är mest sannolikt ansvarig för denna typ av attack?",
-                    SubCategoryId = 7
-                },
-                new QuestionModel()
-                {
-                    Id = 8,
-                    Question = "Med övergången till distansarbete upptäcker vårt företag en ökning av säkerhetsincidenter, inklusive obehörig åtkomst till företagsdata. Vilken åtgärd bör företaget vidta för att adressera denna nya riskmiljö?",
-                    SubCategoryId = 8
-                },
-                new QuestionModel()
-                {
-                    Id = 9,
-                    Question = "Hälsovårdsmyndigheten utsätts för ett cyberangrepp som krypterar patientdata och kräver lösen för att återställa åtkomsten. Vilken typ av angrepp har de sannolikt blivit utsatta för?",
-                    SubCategoryId = 9
-                },
-                new QuestionModel()
-                {
-                    Id = 10,
-                    Question = "Det globala fraktbolaget Maersk blev offer för ett omfattande cyberangrepp som avsevärt störde deras verksamhet världen över. Vilken typ av malware var primärt ansvarig för denna incident?",
-                    SubCategoryId = 10
-                },
-                new QuestionModel()
-                {
-                    Id = 11,
-                    Question = "Regeringen upptäcker att känslig politisk kommunikation har läckt och misstänker elektronisk övervakning. Vilket fenomen beskriver bäst denna situation?",
-                    SubCategoryId = 36
-                },
-                new QuestionModel()
-                {
-                    Id = 12,
-                    Question = "Regeringen blir varse om en sofistikerad skadeprogramskampanj som utnyttjar Zero-day sårbarheter för att infiltrera deras nätverk och stjäla oerhört viktig data. Vilken metod för cyberspionage används sannolikt här?",
-                    SubCategoryId = 37
-                },
-                new QuestionModel()
-                {
-                    Id = 13,
-                    Question = "Regeringen i Sverige ökar sitt interna säkerhetsprotokoll för att skydda sig mot utländska underrättelsetjänsters infiltration. Vilken lagstiftning ger ramverket för detta skydd?",
-                    SubCategoryId = 38
-                },
-                new QuestionModel()
-                {
-                    Id = 14,
-                    Question = "Lunds universitet upptäcker att forskningsdata om ny teknologi har stulits. Undersökningar tyder på en välorganiserad grupp med kopplingar till en utländsk stat. Vilken typ av aktör ligger sannolikt bakom detta?",
-                    SubCategoryId = 39
-                });
-
+            .HasData(
+            new QuestionModel()
+            {
+                Id = 1,
+                Question = "Du får ett oväntat telefonsamtal från någon som påstår sig vara från din bank. Personen ber dig bekräfta ditt kontonummer och lösenord för att \"säkerställa din kontos säkerhet\" efter en påstådd säkerhetsincident. Hur bör du tolka denna situation?",
+                Explanation = "Banker och andra finansiella institutioner begär aldrig känslig information såsom kontonummer eller lösenord via telefon. Detta är ett klassiskt tecken på telefonbedrägeri.",
+                SubCategoryId = 1,
+            },
+            new QuestionModel()
+            {
+                Id = 2,
+                Question = "Efter flera månader av daglig kommunikation med någon du träffade på en datingsida, börjar personen berätta om en plötslig finansiell kris och ber om din hjälp genom att överföra pengar. Vad indikerar detta mest sannolikt?",
+                Explanation = "Begäran om pengar, särskilt under omständigheter där två personer aldrig har träffats fysiskt, är ett vanligt tecken på romansbedrägeri.",
+                SubCategoryId = 2,
+            },
+            new QuestionModel()
+            {
+                Id = 3,
+                Question = "Du får ett e-postmeddelande/samtal om ett exklusivt erbjudande att investera i ett startup-företag som påstås ha en revolutionerande ny teknologi, med garantier om exceptionellt hög avkastning på mycket kort tid. Hur bör du förhålla dig till erbjudandet?",
+                Explanation = "Erbjudanden som lovar hög avkastning med liten eller ingen risk, särskilt via oönskade e-postmeddelanden, är ofta tecken på investeringsbedrägerier.",
+                SubCategoryId = 3,
+            },
+            new QuestionModel()
+            {
+                Id = 4,
+                Question = "Efter en online-shoppingrunda märker du oidentifierade transaktioner på ditt kreditkortsutdrag från företag du aldrig handlat från. Vad indikerar detta mest sannolikt?",
+                Explanation = "Oidentifierade transaktioner på ditt kreditkortsutdrag är en stark indikation på att ditt kortnummer har komprometterats och använts för obehöriga köp, vilket är typiskt för kreditkortsbedrägeri.",
+                SubCategoryId = 4,
+            },
+            new QuestionModel()
+            {
+                Id = 5,
+                Question = "Inom företaget märker man att konfidentiella dokument regelbundet läcker ut till konkurrenter. Efter en intern granskning upptäcks det att en anställd omedvetet har installerat skadlig programvara genom att klicka på en länk i ett phishing-e-postmeddelande. Vilken åtgärd bör prioriteras för att förhindra framtida incidenter?",
+                Explanation = "Utbildning i digital säkerhet är avgörande för att hjälpa anställda att känna igen och undvika säkerhetshot som phishing, vilket är en vanlig attackvektor.",
+                SubCategoryId = 5
+            },
+            new QuestionModel()
+            {
+                Id = 6,
+                Question = "Inom företaget upptäckts det en sårbarhet i vår programvara som kunde möjliggöra obehörig åtkomst till användardata. Företaget har inte omedelbart en lösning. Vilken är den mest lämpliga första åtgärden?",
+                Explanation = "Transparent kommunikation och rådgivning om tillfälliga åtgärder är avgörande för att skydda användarna medan en permanent lösning utvecklas.",
+                SubCategoryId = 6
+            },
+            new QuestionModel()
+            {
+                Id = 7,
+                Question = "Vårt företag blir måltavla för en DDoS-attack som överväldigar våra servrar och gör våra tjänster otillgängliga för kunder. Vilken typ av aktör är mest sannolikt ansvarig för denna typ av attack?",
+                Explanation = "DDoS-attacker kräver ofta betydande resurser och koordinering, vilket är karakteristiskt för organiserade cyberbrottsliga grupper.",
+                SubCategoryId = 7
+            },
+            new QuestionModel()
+            {
+                Id = 8,
+                Question = "Med övergången till distansarbete upptäcker vårt företag en ökning av säkerhetsincidenter, inklusive obehörig åtkomst till företagsdata. Vilken åtgärd bör företaget vidta för att adressera denna nya riskmiljö?",
+                Explanation = "Stärkt autentisering är kritisk för att säkra fjärråtkomst och skydda mot obehörig åtkomst i en distribuerad arbetsmiljö.",
+                SubCategoryId = 8
+            },
+            new QuestionModel()
+            {
+                Id = 9,
+                Question = "Hälsovårdsmyndigheten utsätts för ett cyberangrepp som krypterar patientdata och kräver lösen för att återställa åtkomsten. Vilken typ av angrepp har de sannolikt blivit utsatta för?",
+                Explanation = "Ransomware-angrepp involverar kryptering av offerdata och kräver lösen för dekryptering, vilket är särskilt skadligt för kritiska sektorer som hälsovård.",
+                SubCategoryId = 9
+            },
+            new QuestionModel()
+            {
+                Id = 10,
+                Question = "Det globala fraktbolaget Maersk blev offer för ett omfattande cyberangrepp som avsevärt störde deras verksamhet världen över. Vilken typ av malware var primärt ansvarig för denna incident?",
+                Explanation = "Maersk utsattes för NotPetya ransomware-angreppet, som ledde till omfattande störningar och förluster genom att kryptera företagets globala system. \r\n\r\nMaersk rapporterade att företaget led ekonomiska förluster på grund av NotPetya ransomware-angreppet som uppskattades till cirka 300 miljoner USD. Denna siffra reflekterar de omfattande kostnaderna för störningar i deras globala verksamheter, återställande av system och data, samt förlust av affärer under tiden systemen var nere. NotPetya-angreppet anses vara ett av de mest kostsamma cyberangreppen mot ett enskilt företag och tjänar som en kraftfull påminnelse om de potentiella konsekvenserna av cyberhot. ",
+                SubCategoryId = 10
+            },
+            new QuestionModel()
+            {
+                Id = 11,
+                Question = "Regeringen upptäcker att känslig politisk kommunikation har läckt och misstänker elektronisk övervakning. Vilket fenomen beskriver bäst denna situation?",
+                Explanation = "Cyberspionage avser aktiviteter där aktörer, ofta statliga, engagerar sig i övervakning och datainsamling genom cybermedel för att erhålla hemlig information utan målets medgivande, typiskt för politiska, militära eller ekonomiska fördelar.",
+                SubCategoryId = 36
+            },
+            new QuestionModel()
+            {
+                Id = 12,
+                Question = "Regeringen blir varse om en sofistikerad skadeprogramskampanj som utnyttjar Zero-day sårbarheter för att infiltrera deras nätverk och stjäla oerhört viktig data. Vilken metod för cyberspionage används sannolikt här?",
+                Explanation = "Riktade cyberattacker som utnyttjar noll-dagars Zero-day sårbarheter är en avancerad metod för cyberspionage där angriparen specifikt riktar in sig på ett mål för att komma åt känslig information eller data genom att utnyttja tidigare okända sårbarheter i programvara.",
+                SubCategoryId = 37
+            },
+            new QuestionModel()
+            {
+                Id = 13,
+                Question = "Regeringen i Sverige ökar sitt interna säkerhetsprotokoll för att skydda sig mot utländska underrättelsetjänsters infiltration. Vilken lagstiftning ger ramverket för detta skydd?",
+                Explanation = "Säkerhetsskyddslagen är en svensk lagstiftning som syftar till att skydda nationellt känslig information från spioneri, sabotage, terroristbrott och andra säkerhetshot. Lagen ställer krav på säkerhetsskyddsåtgärder för verksamheter av betydelse för Sveriges säkerhet.",
+                SubCategoryId = 38
+            },
+            new QuestionModel()
+            {
+                Id = 14,
+                Question = "Lunds universitet upptäcker att forskningsdata om ny teknologi har stulits. Undersökningar tyder på en välorganiserad grupp med kopplingar till en utländsk stat. Vilken typ av aktör ligger sannolikt bakom detta?",
+                Explanation = "Statssponsrade hackers är aktörer som arbetar på uppdrag av eller med stöd från en regering för att genomföra cyberspionage, ofta riktat mot utländska intressen, organisationer eller regeringar för att få strategiska fördelar.",
+                SubCategoryId = 39
+            },
+            new QuestionModel()
+            {
+                Id = 15,
+                Question = "Du får ett e-postmeddelande som ser ut att komma från din bank. Det ber dig klicka på en länk och logga in på ditt konto för att “uppdatera din information”. Vad bör du göra?",
+                Explanation = "Klicka aldrig på länkar som uppges komma från banker via e-post.",
+                SubCategoryId = 1
+            },
+            new QuestionModel()
+            {
+                Id = 16,
+                Question = "Du använder din kreditkort på en betalterminal i en butik. Någon har placerat en skimming-enhet på terminalen för att stjäla kortinformation. Vad bör du vara vaksam på?",
+                Explanation = "Skimming är en metod där bedragare placerar en enhet på en betalterminal för att stjäla kortinformation. Genom att inspektera terminalen kan du upptäcka ovanliga tillbehör eller lösa delar som kan indikera att skimming-enheten är närvarande.",
+                SubCategoryId = 1
+            },
+            new QuestionModel()
+            {
+                Id = 17,
+                Question = "Du får ett meddelande om en större transaktion på ditt kreditkort som du inte har gjort. Vad bör du göra?",
+                Explanation = "Om du ser en större transaktion på ditt kreditkort som du inte har gjort, bör du agera snabbt. Att kontakta din kreditkortsutgivare direkt hjälper till att förhindra ytterligare skada och identifiera eventuellt bedrägeri.",
+                SubCategoryId = 1
+            },
+            new QuestionModel()
+            {
+                Id = 18,
+                Question = "Du får en e-post med en bifogad faktura från ett företag du inte känner till. Vad bör du göra?",
+                Explanation = "Att öppna bifogade fakturor från okända avsändare kan vara farligt. Radera e-postmeddelandet för att undvika att utsätta dig för skadlig kod eller bedrägeriförsök.",
+                SubCategoryId = 1
+            },
+            new QuestionModel()
+            {
+                Id = 19,
+                Question = "Du ser någon slarvigt lämna sitt kreditkort på ett cafébord. Vad bör du göra?",
+                Explanation = "Att ta någon annans kreditkort och använda det är olagligt och oetiskt. Lämna kortet där du hittade det eller ge det till personalen för att returnera det till ägaren.",
+                SubCategoryId = 1
+            },
+            new QuestionModel
+            {
+                Id = 20,
+                Question = "Du har flera automatiska betalningar kopplade till ditt kreditkort. Vad bör du göra om du byter kreditkort?",
+                Explanation = "Om du byter kreditkort är det viktigt att uppdatera betalningsuppgifterna för alla automatiska betalningar. Annars kan du missa betalningar och få påminnelser eller avgifter.",
+                SubCategoryId = 1
+            },
+            new QuestionModel()
+            {
+                Id = 21,
+                Question = "Vad är ett romansbedrägeri?",
+                Explanation = "Ett romansbedrägeri är när en bedragare inleder en romantisk relation med någon i syfte att lura hen på pengar. Det sker oftast på internet, till exempel på sociala medier samt dejtingsidor och dejtingappar.",
+                SubCategoryId = 2
+            },
+            new QuestionModel()
+            {
+                Id = 22,
+                Question = "Vilka typiska drag bör du vara uppmärksam på hos en romansbedragare?",
+                Explanation = "Uppmärksamma typiska drag för en romansbedragare, såsom statusyrken, konstlade formuleringar eller slarvigt språkbruk.",
+                SubCategoryId = 2
+            },
+            new QuestionModel()
+            {
+                Id = 23,
+                Question = "Vad krävs för att någon ska åtalas för romansbedrägeri?",
+                Explanation = "Romansbedrägeri är brottsligt när någon inleder en kärleksrelation med dig för att lura dig på pengar. Åtal kan väckas om det finns bevis för detta bedrägeri.",
+                SubCategoryId = 2
+            },
+            new QuestionModel()
+            {
+                Id = 24,
+                Question = "Vad bör du göra om du misstänker att du blivit utsatt för romansbedrägeri på nätet?",
+                Explanation = "Om du blivit lurad av kärleken du träffat på nätet bör du lista ut vad du ska göra när du blivit utsatt och vart du ska vända dig för hjälp.",
+                SubCategoryId = 2
+            },
+            new QuestionModel()
+            {
+                Id = 25,
+                Question = "Hur skyddar du dig mot romansbedrägeri?",
+                Explanation = "Det finns flera saker du kan göra för att skydda dig mot romansbedrägeri. Följ tips och råd om hur du kan undvika att bli lurad.",
+                SubCategoryId = 2
+            },
+            new QuestionModel()
+            {
+                Id = 26,
+                Question = "Vad är ett investeringsbedrägeri?",
+                Explanation = "Ett investeringsbedrägeri innebär att någon lurar andra att köpa värdepapper som egentligen inte har något värde eller som är väldigt svåra att värdera. Det kan handla om investeringar i fonder, aktier, kryptovalutor samt metaller och ädelstenar.",
+                SubCategoryId = 3
+            },
+            new QuestionModel()
+            {
+                Id = 27,
+                Question = "Vilka varningssignaler bör du vara uppmärksam på vid investeringserbjudanden?",
+                Explanation = "Var uppmärksam på varningssignaler som hög avkastning utan risk, bristande dokumentation, och orealistiska löften. Bedragare lockar ofta med snabba vinster och undviker att ge tydlig information om investeringen.",
+                SubCategoryId = 3
+            },
+            new QuestionModel()
+            {
+                Id = 28,
+                Question = "Hur kan du skydda dig mot investeringsbedrägeri?",
+                Explanation = "För att skydda dig mot investeringsbedrägeri bör du vara skeptisk mot orealistiska löften, göra grundlig research om investeringen, och undvika att agera impulsivt. Kontrollera även att företaget har tillstånd från Finansinspektionen.",
+                SubCategoryId = 3
+            },
+            new QuestionModel()
+            {
+                Id = 29,
+                Question = "Vad bör du göra om du misstänker att du blivit utsatt för investeringsbedrägeri?",
+                Explanation = "Om du misstänker att du blivit utsatt för investeringsbedrägeri bör du omedelbart kontakta Polisen och Finansinspektionen. Samla all relevant information och undvik att göra fler transaktioner med bedragaren.",
+                SubCategoryId = 3
+            });
+        }
+        private void SeedAnswerData(ModelBuilder builder)
+        {
             builder.Entity<AnswerModel>()
                 .HasData(
                 new AnswerModel()
@@ -810,6 +948,321 @@ namespace ValhallaVaultCyberAwareness.Data
                     Answer = "Statssponsrade hackers",
                     IsCorrect = true,
                     QuestionId = 14
+                },
+                new AnswerModel()
+                {
+                    Id = 43,
+                    Answer = "Klicka på länken och logga in för att uppdatera din information.",
+                    IsCorrect = false,
+                    QuestionId = 15
+                },
+                new AnswerModel()
+                {
+                    Id = 44,
+                    Answer = "Ignorera e-postmeddelandet och radera det omedelbart.",
+                    IsCorrect = true,
+                    QuestionId = 15
+                },
+                new AnswerModel()
+                {
+                    Id = 45,
+                    Answer = "Skicka ditt kontonummer och lösenord som begärt.",
+                    IsCorrect = false,
+                    QuestionId = 15
+                },
+                new AnswerModel()
+                {
+                    Id = 46,
+                    Answer = "Kontrollera att PIN-koden är synlig för andra.",
+                    IsCorrect = false,
+                    QuestionId = 16
+                },
+                new AnswerModel()
+                {
+                    Id = 47,
+                    Answer = "Inspektera terminalen för ovanliga tillbehör eller lösa delar.",
+                    IsCorrect = true,
+                    QuestionId = 16
+                },
+                new AnswerModel()
+                {
+                    Id = 48,
+                    Answer = "Använd kortet utan att oroa dig.",
+                    IsCorrect = false,
+                    QuestionId = 16
+                },
+                new AnswerModel()
+                {
+                    Id = 49,
+                    Answer = "Ignorera det och anta att det är en felaktighet.",
+                    IsCorrect = false,
+                    QuestionId = 17
+                },
+                new AnswerModel()
+                {
+                    Id = 50,
+                    Answer = "Kontakta din kreditkortsutgivare omedelbart för att rapportera misstänkt bedrägeri.",
+                    IsCorrect = true,
+                    QuestionId = 17
+                },
+                new AnswerModel()
+                {
+                    Id = 51,
+                    Answer = "Vänta och se om det löser sig av sig självt.",
+                    IsCorrect = false,
+                    QuestionId = 17
+                },
+                new AnswerModel()
+                {
+                    Id = 52,
+                    Answer = "Öppna fakturan och betala den om den verkar legitim.",
+                    IsCorrect = false,
+                    QuestionId = 18
+                },
+                new AnswerModel()
+                {
+                    Id = 53,
+                    Answer = "Kontakta din kreditkortsutgivare omedelbart för att rapportera misstänkt bedrägeri.",
+                    IsCorrect = true,
+                    QuestionId = 18
+                },
+                new AnswerModel()
+                {
+                    Id = 54,
+                    Answer = "Vänta och se om det löser sig av sig självt.",
+                    IsCorrect = false,
+                    QuestionId = 18
+                },
+                new AnswerModel()
+                {
+                    Id = 55,
+                    Answer = "Ta kortet och använd det för egna inköp.",
+                    IsCorrect = false,
+                    QuestionId = 19
+                },
+                new AnswerModel()
+                {
+                    Id = 56,
+                    Answer = "Ge kortet till personalen på caféet.",
+                    IsCorrect = true,
+                    QuestionId = 19
+                },
+                new AnswerModel()
+                {
+                    Id = 57,
+                    Answer = "Klipp sönder kortet.",
+                    IsCorrect = false,
+                    QuestionId = 19
+                },
+                new AnswerModel()
+                {
+                    Id = 58,
+                    Answer = "Glöm bort det och låt betalningarna fortsätta.",
+                    IsCorrect = false,
+                    QuestionId = 20
+                },
+                new AnswerModel()
+                {
+                    Id = 59,
+                    Answer = "Uppdatera betalningsuppgifterna hos varje tjänsteleverantör.",
+                    IsCorrect = true,
+                    QuestionId = 20
+                },
+                new AnswerModel()
+                {
+                    Id = 60,
+                    Answer = "Avbryt alla automatiska betalningar.",
+                    IsCorrect = false,
+                    QuestionId = 20
+                },
+                new AnswerModel()
+                {
+                    Id = 61,
+                    Answer = "Ett romansbedrägeri är när en bedragare inleder en romantisk relation med någon i syfte att lura hen på pengar. Det sker oftast på internet, till exempel på sociala medier samt dejtingsidor och dejtingappar.",
+                    IsCorrect = true,
+                    QuestionId = 21
+                },
+                new AnswerModel()
+                {
+                    Id = 62,
+                    Answer = "Det är när två personer fejkar en romantisk relation för att lura andra.",
+                    IsCorrect = false,
+                    QuestionId = 21
+                },
+                new AnswerModel()
+                {
+                    Id = 63,
+                    Answer = "Det handlar om att skapa en falsk identitet för att vinna någon annans förtroende.",
+                    IsCorrect = false,
+                    QuestionId = 21
+                },
+                new AnswerModel()
+                {
+                    Id = 64,
+                    Answer = "Statusyrken, konstlade formuleringar eller slarvigt språkbruk.",
+                    IsCorrect = true,
+                    QuestionId = 22
+                },
+                new AnswerModel()
+                {
+                    Id = 65,
+                    Answer = "Generös gåva av blommor eller choklad.",
+                    IsCorrect = false,
+                    QuestionId = 22
+                },
+                new AnswerModel()
+                {
+                    Id = 66,
+                    Answer = "Överdriven romantik och kärleksgestikulering.",
+                    IsCorrect = false,
+                    QuestionId = 22
+                },
+                new AnswerModel()
+                {
+                    Id = 67,
+                    Answer = "Bevis för att personen inlett en kärleksrelation för att lura på pengar.",
+                    IsCorrect = true,
+                    QuestionId = 23
+                },
+                new AnswerModel()
+                {
+                    Id = 68,
+                    Answer = "Att personen har skickat kärleksbrev eller romantiska meddelanden.",
+                    IsCorrect = false,
+                    QuestionId = 23
+                },
+                new AnswerModel()
+                {
+                    Id = 69,
+                    Answer = "Att personen har använt falsk identitet på sociala medier.",
+                    IsCorrect = false,
+                    QuestionId = 23
+                },
+                new AnswerModel()
+                {
+                    Id = 70,
+                    Answer = "Fortsätta kommunicera för att samla mer bevis.",
+                    IsCorrect = false,
+                    QuestionId = 24
+                },
+                new AnswerModel()
+                {
+                    Id = 71,
+                    Answer = "Avsluta all kontakt med personen och blockera dem.",
+                    IsCorrect = true,
+                    QuestionId = 24
+                },
+                new AnswerModel()
+                {
+                    Id = 72,
+                    Answer = "Dela personlig information för att testa deras äkthet.",
+                    IsCorrect = false,
+                    QuestionId = 24
+                },
+                new AnswerModel()
+                {
+                    Id = 73,
+                    Answer = "Öppet dela dina känslor och livshistoria med okända personer.",
+                    IsCorrect = false,
+                    QuestionId = 25
+                },
+                new AnswerModel()
+                {
+                    Id = 74,
+                    Answer = "Dela personlig information och bankuppgifter direkt.",
+                    IsCorrect = false,
+                    QuestionId = 25
+                },
+                new AnswerModel()
+                {
+                    Id = 75,
+                    Answer = "Var skeptisk mot snabba kärleksförklaringar och ekonomiska problem.",
+                    IsCorrect = true,
+                    QuestionId = 25
+                },
+                new AnswerModel()
+                {
+                    Id = 76,
+                    Answer = "Ett investeringsbedrägeri kan handla om investeringar i fonder, aktier, kryptovalutor samt metaller och ädelstenar.",
+                    IsCorrect = false,
+                    QuestionId = 26
+                },
+                new AnswerModel()
+                {
+                    Id = 77,
+                    Answer = "Det är när någon lurar andra att köpa värdepapper som egentligen inte har något värde eller är svåra att värdera.",
+                    IsCorrect = true,
+                    QuestionId = 26
+                },
+                new AnswerModel()
+                {
+                    Id = 78,
+                    Answer = "Investeringar som garanterar snabba vinster utan risk.",
+                    IsCorrect = false,
+                    QuestionId = 26
+                },
+                new AnswerModel()
+                {
+                    Id = 79,
+                    Answer = "Hög avkastning utan risk, bristande dokumentation, orealistiska löften.",
+                    IsCorrect = true,
+                    QuestionId = 27
+                },
+                new AnswerModel()
+                {
+                    Id = 80,
+                    Answer = "Tydlig information om investeringen, seriösa företag.",
+                    IsCorrect = false,
+                    QuestionId = 27
+                },
+                new AnswerModel()
+                {
+                    Id = 81,
+                    Answer = "Snabba vinster och impulsivt agerande.",
+                    IsCorrect = false,
+                    QuestionId = 27
+                },
+                new AnswerModel()
+                {
+                    Id = 82,
+                    Answer = "Var skeptisk mot orealistiska löften, gör grundlig research, undvik impulsiva beslut.",
+                    IsCorrect = true,
+                    QuestionId = 28
+                },
+                new AnswerModel()
+                {
+                    Id = 83,
+                    Answer = "Dela personlig information och bankuppgifter direkt.",
+                    IsCorrect = false,
+                    QuestionId = 28
+                },
+                new AnswerModel()
+                {
+                    Id = 84,
+                    Answer = "Lita på alla investeringsmöjligheter utan att kontrollera företaget.",
+                    IsCorrect = false,
+                    QuestionId = 28
+                },
+                new AnswerModel()
+                {
+                    Id = 85,
+                    Answer = "Dela personlig information för att testa deras äkthet.",
+                    IsCorrect = false,
+                    QuestionId = 29
+                },
+                new AnswerModel()
+                {
+                    Id = 86,
+                    Answer = "Fortsätta kommunicera för att samla mer bevis.",
+                    IsCorrect = false,
+                    QuestionId = 29
+                },
+                new AnswerModel()
+                {
+                    Id = 87,
+                    Answer = "Avsluta all kontakt med personen och blockera dem.",
+                    IsCorrect = true,
+                    QuestionId = 29
                 });
         }
     }

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Migrations/20240308104131_SeedMoreQuestionsAndAnswers.Designer.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Migrations/20240308104131_SeedMoreQuestionsAndAnswers.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ValhallaVaultCyberAwareness.Data;
 
@@ -11,9 +12,11 @@ using ValhallaVaultCyberAwareness.Data;
 namespace ValhallaVaultCyberAwareness.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240308104131_SeedMoreQuestionsAndAnswers")]
+    partial class SeedMoreQuestionsAndAnswers
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Migrations/20240308104131_SeedMoreQuestionsAndAnswers.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Data/Migrations/20240308104131_SeedMoreQuestionsAndAnswers.cs
@@ -1,0 +1,503 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace ValhallaVaultCyberAwareness.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedMoreQuestionsAndAnswers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "explanation",
+                table: "Questions",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 1,
+                column: "explanation",
+                value: "Banker och andra finansiella institutioner begär aldrig känslig information såsom kontonummer eller lösenord via telefon. Detta är ett klassiskt tecken på telefonbedrägeri.");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 2,
+                column: "explanation",
+                value: "Begäran om pengar, särskilt under omständigheter där två personer aldrig har träffats fysiskt, är ett vanligt tecken på romansbedrägeri.");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 3,
+                column: "explanation",
+                value: "Erbjudanden som lovar hög avkastning med liten eller ingen risk, särskilt via oönskade e-postmeddelanden, är ofta tecken på investeringsbedrägerier.");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 4,
+                column: "explanation",
+                value: "Oidentifierade transaktioner på ditt kreditkortsutdrag är en stark indikation på att ditt kortnummer har komprometterats och använts för obehöriga köp, vilket är typiskt för kreditkortsbedrägeri.");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 5,
+                column: "explanation",
+                value: "Utbildning i digital säkerhet är avgörande för att hjälpa anställda att känna igen och undvika säkerhetshot som phishing, vilket är en vanlig attackvektor.");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 6,
+                column: "explanation",
+                value: "Transparent kommunikation och rådgivning om tillfälliga åtgärder är avgörande för att skydda användarna medan en permanent lösning utvecklas.");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 7,
+                column: "explanation",
+                value: "DDoS-attacker kräver ofta betydande resurser och koordinering, vilket är karakteristiskt för organiserade cyberbrottsliga grupper.");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 8,
+                column: "explanation",
+                value: "Stärkt autentisering är kritisk för att säkra fjärråtkomst och skydda mot obehörig åtkomst i en distribuerad arbetsmiljö.");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 9,
+                column: "explanation",
+                value: "Ransomware-angrepp involverar kryptering av offerdata och kräver lösen för dekryptering, vilket är särskilt skadligt för kritiska sektorer som hälsovård.");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 10,
+                column: "explanation",
+                value: "Maersk utsattes för NotPetya ransomware-angreppet, som ledde till omfattande störningar och förluster genom att kryptera företagets globala system. \r\n\r\nMaersk rapporterade att företaget led ekonomiska förluster på grund av NotPetya ransomware-angreppet som uppskattades till cirka 300 miljoner USD. Denna siffra reflekterar de omfattande kostnaderna för störningar i deras globala verksamheter, återställande av system och data, samt förlust av affärer under tiden systemen var nere. NotPetya-angreppet anses vara ett av de mest kostsamma cyberangreppen mot ett enskilt företag och tjänar som en kraftfull påminnelse om de potentiella konsekvenserna av cyberhot. ");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 11,
+                column: "explanation",
+                value: "Cyberspionage avser aktiviteter där aktörer, ofta statliga, engagerar sig i övervakning och datainsamling genom cybermedel för att erhålla hemlig information utan målets medgivande, typiskt för politiska, militära eller ekonomiska fördelar.");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 12,
+                column: "explanation",
+                value: "Riktade cyberattacker som utnyttjar noll-dagars Zero-day sårbarheter är en avancerad metod för cyberspionage där angriparen specifikt riktar in sig på ett mål för att komma åt känslig information eller data genom att utnyttja tidigare okända sårbarheter i programvara.");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 13,
+                column: "explanation",
+                value: "Säkerhetsskyddslagen är en svensk lagstiftning som syftar till att skydda nationellt känslig information från spioneri, sabotage, terroristbrott och andra säkerhetshot. Lagen ställer krav på säkerhetsskyddsåtgärder för verksamheter av betydelse för Sveriges säkerhet.");
+
+            migrationBuilder.UpdateData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 14,
+                column: "explanation",
+                value: "Statssponsrade hackers är aktörer som arbetar på uppdrag av eller med stöd från en regering för att genomföra cyberspionage, ofta riktat mot utländska intressen, organisationer eller regeringar för att få strategiska fördelar.");
+
+            migrationBuilder.InsertData(
+                table: "Questions",
+                columns: new[] { "id", "explanation", "question", "subcategory_id" },
+                values: new object[,]
+                {
+                    { 15, "Klicka aldrig på länkar som uppges komma från banker via e-post.", "Du får ett e-postmeddelande som ser ut att komma från din bank. Det ber dig klicka på en länk och logga in på ditt konto för att “uppdatera din information”. Vad bör du göra?", 1 },
+                    { 16, "Skimming är en metod där bedragare placerar en enhet på en betalterminal för att stjäla kortinformation. Genom att inspektera terminalen kan du upptäcka ovanliga tillbehör eller lösa delar som kan indikera att skimming-enheten är närvarande.", "Du använder din kreditkort på en betalterminal i en butik. Någon har placerat en skimming-enhet på terminalen för att stjäla kortinformation. Vad bör du vara vaksam på?", 1 },
+                    { 17, "Om du ser en större transaktion på ditt kreditkort som du inte har gjort, bör du agera snabbt. Att kontakta din kreditkortsutgivare direkt hjälper till att förhindra ytterligare skada och identifiera eventuellt bedrägeri.", "Du får ett meddelande om en större transaktion på ditt kreditkort som du inte har gjort. Vad bör du göra?", 1 },
+                    { 18, "Att öppna bifogade fakturor från okända avsändare kan vara farligt. Radera e-postmeddelandet för att undvika att utsätta dig för skadlig kod eller bedrägeriförsök.", "Du får en e-post med en bifogad faktura från ett företag du inte känner till. Vad bör du göra?", 1 },
+                    { 19, "Att ta någon annans kreditkort och använda det är olagligt och oetiskt. Lämna kortet där du hittade det eller ge det till personalen för att returnera det till ägaren.", "Du ser någon slarvigt lämna sitt kreditkort på ett cafébord. Vad bör du göra?", 1 },
+                    { 20, "Om du byter kreditkort är det viktigt att uppdatera betalningsuppgifterna för alla automatiska betalningar. Annars kan du missa betalningar och få påminnelser eller avgifter.", "Du har flera automatiska betalningar kopplade till ditt kreditkort. Vad bör du göra om du byter kreditkort?", 1 },
+                    { 21, "Ett romansbedrägeri är när en bedragare inleder en romantisk relation med någon i syfte att lura hen på pengar. Det sker oftast på internet, till exempel på sociala medier samt dejtingsidor och dejtingappar.", "Vad är ett romansbedrägeri?", 2 },
+                    { 22, "Uppmärksamma typiska drag för en romansbedragare, såsom statusyrken, konstlade formuleringar eller slarvigt språkbruk.", "Vilka typiska drag bör du vara uppmärksam på hos en romansbedragare?", 2 },
+                    { 23, "Romansbedrägeri är brottsligt när någon inleder en kärleksrelation med dig för att lura dig på pengar. Åtal kan väckas om det finns bevis för detta bedrägeri.", "Vad krävs för att någon ska åtalas för romansbedrägeri?", 2 },
+                    { 24, "Om du blivit lurad av kärleken du träffat på nätet bör du lista ut vad du ska göra när du blivit utsatt och vart du ska vända dig för hjälp.", "Vad bör du göra om du misstänker att du blivit utsatt för romansbedrägeri på nätet?", 2 },
+                    { 25, "Det finns flera saker du kan göra för att skydda dig mot romansbedrägeri. Följ tips och råd om hur du kan undvika att bli lurad.", "Hur skyddar du dig mot romansbedrägeri?", 2 },
+                    { 26, "Ett investeringsbedrägeri innebär att någon lurar andra att köpa värdepapper som egentligen inte har något värde eller som är väldigt svåra att värdera. Det kan handla om investeringar i fonder, aktier, kryptovalutor samt metaller och ädelstenar.", "Vad är ett investeringsbedrägeri?", 3 },
+                    { 27, "Var uppmärksam på varningssignaler som hög avkastning utan risk, bristande dokumentation, och orealistiska löften. Bedragare lockar ofta med snabba vinster och undviker att ge tydlig information om investeringen.", "Vilka varningssignaler bör du vara uppmärksam på vid investeringserbjudanden?", 3 },
+                    { 28, "För att skydda dig mot investeringsbedrägeri bör du vara skeptisk mot orealistiska löften, göra grundlig research om investeringen, och undvika att agera impulsivt. Kontrollera även att företaget har tillstånd från Finansinspektionen.", "Hur kan du skydda dig mot investeringsbedrägeri?", 3 },
+                    { 29, "Om du misstänker att du blivit utsatt för investeringsbedrägeri bör du omedelbart kontakta Polisen och Finansinspektionen. Samla all relevant information och undvik att göra fler transaktioner med bedragaren.", "Vad bör du göra om du misstänker att du blivit utsatt för investeringsbedrägeri?", 3 }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Answers",
+                columns: new[] { "id", "answer", "is_correct", "question_id" },
+                values: new object[,]
+                {
+                    { 43, "Klicka på länken och logga in för att uppdatera din information.", false, 15 },
+                    { 44, "Ignorera e-postmeddelandet och radera det omedelbart.", true, 15 },
+                    { 45, "Skicka ditt kontonummer och lösenord som begärt.", false, 15 },
+                    { 46, "Kontrollera att PIN-koden är synlig för andra.", false, 16 },
+                    { 47, "Inspektera terminalen för ovanliga tillbehör eller lösa delar.", true, 16 },
+                    { 48, "Använd kortet utan att oroa dig.", false, 16 },
+                    { 49, "Ignorera det och anta att det är en felaktighet.", false, 17 },
+                    { 50, "Kontakta din kreditkortsutgivare omedelbart för att rapportera misstänkt bedrägeri.", true, 17 },
+                    { 51, "Vänta och se om det löser sig av sig självt.", false, 17 },
+                    { 52, "Öppna fakturan och betala den om den verkar legitim.", false, 18 },
+                    { 53, "Kontakta din kreditkortsutgivare omedelbart för att rapportera misstänkt bedrägeri.", true, 18 },
+                    { 54, "Vänta och se om det löser sig av sig självt.", false, 18 },
+                    { 55, "Ta kortet och använd det för egna inköp.", false, 19 },
+                    { 56, "Ge kortet till personalen på caféet.", true, 19 },
+                    { 57, "Klipp sönder kortet.", false, 19 },
+                    { 58, "Glöm bort det och låt betalningarna fortsätta.", false, 20 },
+                    { 59, "Uppdatera betalningsuppgifterna hos varje tjänsteleverantör.", true, 20 },
+                    { 60, "Avbryt alla automatiska betalningar.", false, 20 },
+                    { 61, "Ett romansbedrägeri är när en bedragare inleder en romantisk relation med någon i syfte att lura hen på pengar. Det sker oftast på internet, till exempel på sociala medier samt dejtingsidor och dejtingappar.", true, 21 },
+                    { 62, "Det är när två personer fejkar en romantisk relation för att lura andra.", false, 21 },
+                    { 63, "Det handlar om att skapa en falsk identitet för att vinna någon annans förtroende.", false, 21 },
+                    { 64, "Statusyrken, konstlade formuleringar eller slarvigt språkbruk.", true, 22 },
+                    { 65, "Generös gåva av blommor eller choklad.", false, 22 },
+                    { 66, "Överdriven romantik och kärleksgestikulering.", false, 22 },
+                    { 67, "Bevis för att personen inlett en kärleksrelation för att lura på pengar.", true, 23 },
+                    { 68, "Att personen har skickat kärleksbrev eller romantiska meddelanden.", false, 23 },
+                    { 69, "Att personen har använt falsk identitet på sociala medier.", false, 23 },
+                    { 70, "Fortsätta kommunicera för att samla mer bevis.", false, 24 },
+                    { 71, "Avsluta all kontakt med personen och blockera dem.", true, 24 },
+                    { 72, "Dela personlig information för att testa deras äkthet.", false, 24 },
+                    { 73, "Öppet dela dina känslor och livshistoria med okända personer.", false, 25 },
+                    { 74, "Dela personlig information och bankuppgifter direkt.", false, 25 },
+                    { 75, "Var skeptisk mot snabba kärleksförklaringar och ekonomiska problem.", true, 25 },
+                    { 76, "Ett investeringsbedrägeri kan handla om investeringar i fonder, aktier, kryptovalutor samt metaller och ädelstenar.", false, 26 },
+                    { 77, "Det är när någon lurar andra att köpa värdepapper som egentligen inte har något värde eller är svåra att värdera.", true, 26 },
+                    { 78, "Investeringar som garanterar snabba vinster utan risk.", false, 26 },
+                    { 79, "Hög avkastning utan risk, bristande dokumentation, orealistiska löften.", true, 27 },
+                    { 80, "Tydlig information om investeringen, seriösa företag.", false, 27 },
+                    { 81, "Snabba vinster och impulsivt agerande.", false, 27 },
+                    { 82, "Var skeptisk mot orealistiska löften, gör grundlig research, undvik impulsiva beslut.", true, 28 },
+                    { 83, "Dela personlig information och bankuppgifter direkt.", false, 28 },
+                    { 84, "Lita på alla investeringsmöjligheter utan att kontrollera företaget.", false, 28 },
+                    { 85, "Dela personlig information för att testa deras äkthet.", false, 29 },
+                    { 86, "Fortsätta kommunicera för att samla mer bevis.", false, 29 },
+                    { 87, "Avsluta all kontakt med personen och blockera dem.", true, 29 }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 43);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 44);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 45);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 46);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 47);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 48);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 49);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 50);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 51);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 52);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 53);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 54);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 55);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 56);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 57);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 58);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 59);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 60);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 61);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 62);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 63);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 64);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 65);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 66);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 67);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 68);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 69);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 70);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 71);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 72);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 73);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 74);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 75);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 76);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 77);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 78);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 79);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 80);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 81);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 82);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 83);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 84);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 85);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 86);
+
+            migrationBuilder.DeleteData(
+                table: "Answers",
+                keyColumn: "id",
+                keyValue: 87);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 15);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 16);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 17);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 18);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 19);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 20);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 21);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 22);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 23);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 24);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 25);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 26);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 27);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 28);
+
+            migrationBuilder.DeleteData(
+                table: "Questions",
+                keyColumn: "id",
+                keyValue: 29);
+
+            migrationBuilder.DropColumn(
+                name: "explanation",
+                table: "Questions");
+        }
+    }
+}

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Repositories/QuestionRepository.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness/Repositories/QuestionRepository.cs
@@ -53,6 +53,7 @@ namespace ValhallaVaultCyberAwareness.Repositories
             if (questionToUpdate != null)
             {
                 questionToUpdate.Question = question.Question;
+                questionToUpdate.Explanation = question.Explanation;
                 await _context.SaveChangesAsync();
                 return questionToUpdate;
             }


### PR DESCRIPTION
Updated questionmodel with property "Explanation" which holds the explanation to the correct answer.
In the data-seeding I have filled in explanation for each question and added some more questions and answers as well.

SubCategory 1: 7 questions
SubCategory 2: 6 questions
SubCategory 3: 5 questions
The rest has one question each.

Segment 1: 19 questions
Segment 2: 4 questions
Segment 3: 2 questions
Segment 4: 4 questions