### PR TITLE
Add viewmodels for segment and subcategory

### DIFF
--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness.Client/Pages/Counter.razor
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness.Client/Pages/Counter.razor
@@ -1,6 +1,7 @@
 ﻿@page "/counter"
 @using Microsoft.AspNetCore.Identity
 @using ValhallaVaultCyberAwareness.Client.Services
+@using ValhallaVaultCyberAwareness.Client.ViewModels
 @using ValhallaVaultCyberAwareness.Data
 @using ValhallaVaultCyberAwareness.Domain.Models
 @rendermode InteractiveAuto
@@ -8,8 +9,8 @@
 @inject ISegmentService segmentService;
 @inject IQuestionService questionService
 @inject ISubCategoryService subCategoryService;
-@inject UserManager<ApplicationUser> UserManager
-
+@* @inject UserManager<ApplicationUser> UserManager
+ *@
 <PageTitle>Counter</PageTitle>
 
 <h1>Counter</h1>
@@ -18,8 +19,38 @@
 
 <button class="btn btn-primary" @onclick="IncrementCount">Click me</button>
 
+@* DEMO TO TEST CONCEPT WITH VIEWMODELS *@
+
+@foreach(SegmentUserScoreViewModel segmentUserScore in SegmentUserScores)
+{
+    //Access the segment name
+    <p>Segment name: @segmentUserScore.SegmentName</p>
+
+    //Access the segment desription
+    <p>Segment description: @segmentUserScore.SegmentDescription</p>
+
+    //Access if the user has completed this segment (true/false)
+    <p>User has completed segment: @segmentUserScore.UserHasCompletedSegment</p>
+
+    //Access each subcategory in the segment by looping through it
+    @foreach(var subcategory in segmentUserScore.SubCategoryScores)
+    {
+        //Access the subcategory name
+        <p>Subcategory name: @subcategory.SubCategoryName</p>
+        //Access the users correct answers
+        <p>Correct answers in subcategory: @subcategory.CorrectUserAnswers</p>
+
+        //Access the total question count
+        <p>Total questions: @subcategory.TotalQuestions</p>
+
+        //Access if the user has completed this subcategory (true/false)
+        <p>User has completed subcategory: @subcategory.UserHasCompletedSubCategory</p>
+    }
+}
+
 @code {
     private int currentCount = 0;
+    private List<SegmentUserScoreViewModel> SegmentUserScores = new();
 
     private void IncrementCount()
     {
@@ -30,13 +61,13 @@
     {
         //TEST CALL CATEGORIES
         // List<CategoryModel> allCategories = await categoryService.GetAllCategoriesAsync();
-  
+
         //TEST CALL SEGMENTS
         // List<SegmentModel> allSegments = await segmentService.GetSegmentsByCategoryIdAsync(1, "e547fd1c-ec07-49e1-b2ce-0d326f467c01");
-  
+
         //TEST CALL CATEGORY
         // var category = await categoryService.GetCategoryByIdAsync(1);
-  
+
         //TEST ADD NEW SEGMENT
         // SegmentModel newSegment = new()
         //     {
@@ -45,7 +76,7 @@
         //         CategoryId = 1
         //     };
         // bool isSegmentAdded = await segmentService.AddSegmentAsync(newSegment);
-  
+
         //TEST UPDATE SEGMENT
         // List<SegmentModel> segmentsToUpdate = await segmentService.GetSegmentsByCategoryIdAsync(1, "e547fd1c-ec07-49e1-b2ce-0d326f467c01");
         // SegmentModel segment = new()
@@ -57,10 +88,10 @@
 
         //     };
         // bool isUpdated = await segmentService.UpdateSegmentAsync(segment);
-        
+
         //TEST CALL QUESTIONS
         // List<QuestionModel> allQuestions = await questionService.GetAllQuestionsBySubCategoryId(1);
-  
+
         //TEST ADD NEW QUESTION
         // QuestionModel newQuestion = new QuestionModel
         //  {
@@ -70,9 +101,9 @@
         //  };
 
         //  await questionService.AddQuestionAsync(newQuestion);
-  
+
         //TEST CALL GET USERS IN ROLE
-            var users = await UserManager.GetUsersInRoleAsync("Admin");
+        // var users = await UserManager.GetUsersInRoleAsync("Admin");
 
         //TEST ADD NEW SUBCATEGORY
         // SubCategoryModel newSubCategory = new()
@@ -82,7 +113,7 @@
         //         SegmentId = 1
         //     };
         // bool isAdded = await subCategoryService.AddSubCategoryAsync(newSubCategory);
-  
+
         //TEST REMOVE SUBCATEGORY
         // bool isRemoved = await subCategoryService.RemoveSubCategoryAsync(36);
 
@@ -97,7 +128,7 @@
         //     };
 
         // bool isUpdated = await subCategoryService.UpdateSubCategoryAsync(subToUpdate);
-        
+
         //TEST ADD NEW CATEGORY
         // bool isAdded = await categoryService.AddCategoryAsync(new CategoryModel()
         //     {
@@ -105,10 +136,10 @@
         //         Description = "N/A"
 
         //     });
-        
+
         //TEST REMOVE CATEGORY
         // bool isRemoved = await categoryService.RemoveCategoryAsync(4);
-  
+
         //TEST UPDATE CATEGORY
         // var categories = await categoryService.GetAllCategoriesAsync();
         // var x = await categoryService.UpdateCategoryAsync(new CategoryModel()
@@ -116,17 +147,17 @@
         //         Id = categories[0].Id,
         //         Name = "New category name"
         //     });
-  
+
         //TEST ADD NEW QUESTION
         // var x = await questionService.AddQuestionAsync(new QuestionModel()
         //     {
         //         Question = "How old are you?",
         //         SubCategoryId = 3
         //     });
-  
+
         //TEST REMOVE QUESTION
         // var y = await questionService.RemoveQuestionAsync(12);
-  
+
         //TEST UPDATE QUESTION
         // var a = await questionService.GetAllQuestionsBySubCategoryId(1);
         // var z = await questionService.UpdateQuestionAsync(new QuestionModel()
@@ -134,6 +165,9 @@
         //        Id = a[0].Id,
         //        Question = "How are you doing today????"
         //    });
-        
+
+        //TEST IMPROVED SERVICE CALL FOR SEGMENTS
+        SegmentUserScores = await segmentService.ImprovedGetSegmentsByCategoryIdAsync(1, "3de3f363-9b6f-47e5-b6df-4f43baa4a70d");
+
     }
 }

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness.Client/Services/ISegmentService.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness.Client/Services/ISegmentService.cs
@@ -1,4 +1,5 @@
-﻿using ValhallaVaultCyberAwareness.Domain.Models;
+﻿using ValhallaVaultCyberAwareness.Client.ViewModels;
+using ValhallaVaultCyberAwareness.Domain.Models;
 
 namespace ValhallaVaultCyberAwareness.Client.Services
 {
@@ -7,6 +8,8 @@ namespace ValhallaVaultCyberAwareness.Client.Services
         public HttpClient Client { get; set; }
 
         public Task<List<SegmentModel>> GetSegmentsByCategoryIdAsync(int categoryId, string userId);
+
+        public Task<List<SegmentUserScoreViewModel>> ImprovedGetSegmentsByCategoryIdAsync(int categoryId, string userId);
         public Task<bool> AddSegmentAsync(SegmentModel newSegment);
 
         public Task<bool> RemoveSegmentAsync(int segmentId);

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness.Client/Services/SegmentService.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness.Client/Services/SegmentService.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System.Net.Http.Json;
+using ValhallaVaultCyberAwareness.Client.ViewModels;
 using ValhallaVaultCyberAwareness.Domain.Models;
 
 namespace ValhallaVaultCyberAwareness.Client.Services
@@ -19,7 +20,7 @@ namespace ValhallaVaultCyberAwareness.Client.Services
             if (apiResponse.IsSuccessStatusCode)
             {
                 string jsonSegment = await apiResponse.Content.ReadAsStringAsync();
-                List<SegmentModel> segments = JsonConvert.DeserializeObject<List<SegmentModel>>(jsonSegment);
+                List<SegmentModel>? segments = JsonConvert.DeserializeObject<List<SegmentModel>>(jsonSegment);
                 if (segments == null)
                 {
                     throw new JsonException();
@@ -27,6 +28,27 @@ namespace ValhallaVaultCyberAwareness.Client.Services
                 else
                 {
                     return segments;
+                }
+            }
+            throw new HttpRequestException();
+        }
+
+        public async Task<List<SegmentUserScoreViewModel>> ImprovedGetSegmentsByCategoryIdAsync(int categoryId, string userId)
+        {
+
+            var apiResponse = await Client.GetAsync($"/api/segment/{categoryId}/{userId}");
+            if (apiResponse.IsSuccessStatusCode)
+            {
+                string jsonSegment = await apiResponse.Content.ReadAsStringAsync();
+                List<SegmentModel>? segments = JsonConvert.DeserializeObject<List<SegmentModel>>(jsonSegment);
+                if (segments == null)
+                {
+                    throw new JsonException();
+                }
+                else
+                {
+                    List<SegmentUserScoreViewModel> userScores = segments.Select(s => new SegmentUserScoreViewModel(s)).ToList();
+                    return userScores;
                 }
             }
             throw new HttpRequestException();

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness.Client/ViewModels/SegmentUserScoreViewModel.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness.Client/ViewModels/SegmentUserScoreViewModel.cs
@@ -1,0 +1,33 @@
+﻿using ValhallaVaultCyberAwareness.Domain.Models;
+
+namespace ValhallaVaultCyberAwareness.Client.ViewModels
+{
+    public class SegmentUserScoreViewModel
+    {
+        public int SegmentId { get; set; }
+        public string? SegmentName { get; set; }
+        public string? SegmentDescription { get; set; }
+        public List<SubCategoryModel> SegmentSubCategories { get; set; } = new();
+        public List<QuestionModel> SegmentQuestions { get; set; } = new();
+        public List<SubCategoryScoreViewModel> SubCategoryScores { get; set; } = new();
+        public bool UserHasCompletedSegment { get; set; }
+
+        public SegmentUserScoreViewModel(SegmentModel segment)
+        {
+            SegmentId = segment.Id;
+            SegmentName = segment.Name;
+            SegmentDescription = segment.Description;
+            SegmentSubCategories = segment.SubCategories;
+            SubCategoryScores = segment.SubCategories.Select(s => new SubCategoryScoreViewModel(s)).ToList();
+            foreach (var subCategoryScore in SubCategoryScores)
+            {
+                if (subCategoryScore.UserHasCompletedSubCategory == false)
+                {
+                    UserHasCompletedSegment = false;
+                    break;
+                }
+                UserHasCompletedSegment = true;
+            }
+        }
+    }
+}

--- a/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness.Client/ViewModels/SubCategoryScoreViewModel.cs
+++ b/ValhallaVaultCyberAwareness/ValhallaVaultCyberAwareness.Client/ViewModels/SubCategoryScoreViewModel.cs
@@ -1,0 +1,50 @@
+﻿using ValhallaVaultCyberAwareness.Domain.Models;
+
+namespace ValhallaVaultCyberAwareness.Client.ViewModels
+{
+    public class SubCategoryScoreViewModel
+    {
+        public int SubCategoryId { get; set; }
+        public string SubCategoryName { get; set; } = null!;
+        public string? SubCategoryDescription { get; set; }
+        public int CorrectUserAnswers { get; set; }
+        public int TotalQuestions { get; set; }
+        public bool UserHasCompletedSubCategory { get; set; }
+        private double CompletionPercentage { get; set; } = 0.80;
+
+
+        public SubCategoryScoreViewModel(SubCategoryModel subCategory)
+        {
+            SubCategoryId = subCategory.Id;
+            SubCategoryName = subCategory.Name;
+            SubCategoryDescription = subCategory.Description;
+            TotalQuestions = subCategory.Questions.Count;
+            foreach (QuestionModel question in subCategory.Questions)
+            {
+                //Find out the correct answer
+                AnswerModel correctAnswer = question.Answers.First(a => a.IsCorrect);
+
+                //Check if the user has correctly answered this question
+                if (correctAnswer.UserAnswers.Any())
+                {
+                    //Add to the total count of correct answers in this subcategory
+                    CorrectUserAnswers++;
+
+                }
+            }
+            //Calculate the success percentage
+            double completionPercentage = (double)CorrectUserAnswers / (double)subCategory.Questions.Count;
+            //If the success percentage is over the threshold or NaN (which will be the case if the subcategory doesn't contain any questions).
+            if (completionPercentage >= CompletionPercentage || Double.IsNaN(completionPercentage))
+            {
+                //Add true as the value if the user has passed enough in this subcategory.
+                UserHasCompletedSubCategory = true;
+            }
+            else
+            {
+                //If not, add false as the value
+                UserHasCompletedSubCategory = false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implement viewmodels for segment-user-scores and subcategory-user-scores to make it easier for the client pages to process the information.
On the page "Counter" a demo is set up to display how we can access the info in the client pages.